### PR TITLE
Arrived message needs added to end of trip

### DIFF
--- a/docs/api/asynapi.yaml
+++ b/docs/api/asynapi.yaml
@@ -201,7 +201,7 @@ components:
     arrived:
       name: arrived
       title: Arrived
-      summary: Notifies the client that the reserved boat has arrived at the source dock and the gangway is open
+      summary: Notifies the client that the reserved boat has arrived at the source dock, or it has arrived at the destination dock, and the gangway is open
       payload:
         type: object
         properties:
@@ -228,7 +228,7 @@ components:
           $ref: '#/components/schemas/address'
         gangway:
           type: string
-          description: The ramp that will be used to board the boat
+          description: The ramp that will be used to board or disembark from the boat
           enum: [
             "fore",
             "aft"

--- a/proto/adapter.pb.go
+++ b/proto/adapter.pb.go
@@ -294,7 +294,7 @@ func (x *ClientData) GetConnType() string {
 // sends to the MockLogic
 type ReserveTripAPIMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// message_type is a const = "reserve_trip"
+	// message_type is a const = "reserveTrip"
 	MessageType     string `protobuf:"bytes,1,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
 	AuthToken       string `protobuf:"bytes,2,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
 	ClientId        string `protobuf:"bytes,3,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
@@ -452,7 +452,7 @@ func (x *AckAPIMessage) GetTransactionId() string {
 // sends to the MockLogic
 type AtDockAPIMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// message_type is a const = "at_dock"
+	// message_type is a const = "atDock"
 	MessageType   string `protobuf:"bytes,1,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
 	ClientId      string `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	Boat          *Boat  `protobuf:"bytes,3,opt,name=boat,proto3" json:"boat,omitempty"`
@@ -531,7 +531,7 @@ func (x *AtDockAPIMessage) GetTransactionId() string {
 // sends to the MockLogic
 type OnBoatAPIMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// message_type is a const = "on_boat"
+	// message_type is a const = "onBoat"
 	MessageType   string `protobuf:"bytes,1,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
 	ClientId      string `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	Boat          *Boat  `protobuf:"bytes,3,opt,name=boat,proto3" json:"boat,omitempty"`
@@ -602,7 +602,7 @@ func (x *OnBoatAPIMessage) GetTransactionId() string {
 // sends to the MockLogic
 type OffBoatAPIMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// message_type is a const = "off_boat"
+	// message_type is a const = "offBoat"
 	MessageType   string `protobuf:"bytes,1,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
 	ClientId      string `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
 	Boat          *Boat  `protobuf:"bytes,3,opt,name=boat,proto3" json:"boat,omitempty"`
@@ -673,7 +673,7 @@ func (x *OffBoatAPIMessage) GetTransactionId() string {
 // sends to all clients
 type BoatStatusAPIMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// message_type is a const = "boat_status"
+	// message_type is a const = "boatStatus"
 	MessageType   string       `protobuf:"bytes,1,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
 	Boat          *Boat        `protobuf:"bytes,2,opt,name=boat,proto3" json:"boat,omitempty"`
 	ServiceState  ServiceState `protobuf:"varint,3,opt,name=service_state,json=serviceState,proto3,enum=adapter.ServiceState" json:"service_state,omitempty"`

--- a/proto/adapter.proto
+++ b/proto/adapter.proto
@@ -89,7 +89,7 @@ message ClientData {
 // ReserveTripAPIMessage represents the ReserveTrip API message that a client
 // sends to the MockLogic
 message ReserveTripAPIMessage {
-    // message_type is a const = "reserve_trip"
+    // message_type is a const = "reserveTrip"
     string message_type     = 1;
     string auth_token       = 2;
     string client_id        = 3;
@@ -111,7 +111,7 @@ message AckAPIMessage {
 // AtDockAPIMessage reperesents the AtDock API message that the client
 // sends to the MockLogic
 message AtDockAPIMessage {
-    // message_type is a const = "at_dock"
+    // message_type is a const = "atDock"
     string message_type   = 1;
     string client_id      = 2;
     Boat   boat           = 3;
@@ -122,7 +122,7 @@ message AtDockAPIMessage {
 // OnBoatAPIMessage reperesents the OnBoat API message that the client
 // sends to the MockLogic
 message OnBoatAPIMessage {
-    // message_type is a const = "on_boat"
+    // message_type is a const = "onBoat"
     string message_type   = 1;
     string client_id      = 2;
     Boat   boat           = 3;
@@ -132,7 +132,7 @@ message OnBoatAPIMessage {
 // OffBoatAPIMessage reperesents the OffBoat API message that the client
 // sends to the MockLogic
 message OffBoatAPIMessage {
-    // message_type is a const = "off_boat"
+    // message_type is a const = "offBoat"
     string message_type   = 1;
     string client_id      = 2;
     Boat   boat           = 3;
@@ -142,7 +142,7 @@ message OffBoatAPIMessage {
 // BoatStatusAPIMessage represents the BoatStatus API message that the MockLogic
 // sends to all clients
 message BoatStatusAPIMessage {
-    // message_type is a const = "boat_status"
+    // message_type is a const = "boatStatus"
     string       message_type  = 1;
     Boat         boat          = 2;
     ServiceState service_state = 3;


### PR DESCRIPTION
## What I did:

- Changed the wording of the Arrived description




## Why I did it:

The Arrived message will need to be sent when the boat arrives at the destination dock along with the source dock, so clients will know when to leave the boat.




## How to test:

Closes #3 



