### PR TITLE
SimDockAdjacencyList needs changed to map for faster lookup

### DIFF
--- a/mocklogic/mocklogicmodule/mocklogic_reservedtrips.go
+++ b/mocklogic/mocklogicmodule/mocklogic_reservedtrips.go
@@ -151,11 +151,7 @@ func ReturnDistance(start, goal a.Dock) int8 {
 	// Get the next dock after start and recursively call
 	// ReturnDistance()
 	var nextDock a.Dock
-	for _, dockList := range SimDockAdjacencyList {
-		if dockList.Front().Value == start {
-			nextDock = dockList.Front().Next().Value.(a.Dock)
-		}
-	}
+	nextDock = SimDockAdjacencyList[start.Address.Street].Front().Value.(a.Dock)
 
 	return 1 + ReturnDistance(nextDock, goal)
 }

--- a/mocklogic/mocklogicmodule/mocklogic_simulationframes.go
+++ b/mocklogic/mocklogicmodule/mocklogic_simulationframes.go
@@ -394,16 +394,15 @@ func AdvanceSimFrames() {
 	}
 }
 
-// BuildDockAdjacencyList places the SimDocks in a []list.List containers.
-// This adjacency list stores the order of the docks that the boats
+// BuildDockAdjacencyList places the SimDocks in a map[string]*list.List
+// container. This adjacency list stores the order of the docks that the boats
 // travel
-func BuildDockAdjacencyList() []*list.List {
+func BuildDockAdjacencyList() map[string]*list.List {
 	docks := []a.Dock{SimDock1, SimDock2, SimDock3, SimDock4}
-	var adjacencyList []*list.List
+	var adjacencyList = make(map[string]*list.List)
 
 	for i, dock := range docks {
 		list := list.New()
-		_ = list.PushBack(dock)
 		if i < len(docks)-1 {
 			_ = list.PushBack(docks[i+1])
 		} else {
@@ -411,7 +410,7 @@ func BuildDockAdjacencyList() []*list.List {
 			// dock onto the list
 			_ = list.PushBack(docks[0])
 		}
-		adjacencyList = append(adjacencyList, list)
+		adjacencyList[dock.Address.Street] = list
 	}
 
 	return adjacencyList

--- a/mocklogic/mocklogicmodule/mocklogicmodule.go
+++ b/mocklogic/mocklogicmodule/mocklogicmodule.go
@@ -28,7 +28,7 @@ var LogDirectory string
 var SimFrameRing *ring.Ring
 var StopSimFrames chan int
 var SimFrameBoatStatusChannel chan a.BoatStatusAPIMessage
-var SimDockAdjacencyList []*list.List
+var SimDockAdjacencyList map[string]*list.List
 
 // gRPC related
 var GRPCDialTimer *time.Timer


### PR DESCRIPTION
## What I did:

- Changed the sim dock adjacency list to a map 


## Why I did it:

Using a map is a faster lookup for the dock lists associated with each dock. 


## How to test:

- Check out this branch
- `cd riden`
- Run `make mocklogicmodule_test`
- Ensure all unit tests pass

Closes #4 

