### PR TITLE
Adapter mock logic communication functions need select statements

### DIFF
--- a/adapter/adaptermodule/adapter_mocklogiccommunication.go
+++ b/adapter/adaptermodule/adapter_mocklogiccommunication.go
@@ -75,7 +75,11 @@ func ProcessMessageToMockLogic(mlMsg *MockLogicMessage) {
 		}
 		reserveTripMockLogicMsg := a.NewReserveTripMockLogicMessage(apiMsg, clientData)
 
-		GRPCChans.ReserveTripChannel <- reserveTripMockLogicMsg
+		select {
+		case GRPCChans.ReserveTripChannel <- reserveTripMockLogicMsg:
+		default:
+			Logger.Error().Msgf("could not place messaage on ReserveTripChannel: %+v", reserveTripMockLogicMsg)
+		}
 
 	case a.APIMessageTypeAtDock:
 		Logger.Info().Msgf("Processing %s message to MockLogic from ConnName: %s, ConnType: %s",
@@ -91,7 +95,11 @@ func ProcessMessageToMockLogic(mlMsg *MockLogicMessage) {
 
 		atDockMockLogicMessage := a.NewAtDockMockLogicMessage(apiMsg, clientData)
 
-		GRPCChans.AtDockChannel <- atDockMockLogicMessage
+		select {
+		case GRPCChans.AtDockChannel <- atDockMockLogicMessage:
+		default:
+			Logger.Error().Msgf("could not place messaage on AtDockChannel: %+v", atDockMockLogicMessage)
+		}
 
 	case a.APIMessageTypeOnBoat:
 		Logger.Info().Msgf("Processing %s message to MockLogic from ConnName: %s, ConnType: %s",
@@ -107,7 +115,11 @@ func ProcessMessageToMockLogic(mlMsg *MockLogicMessage) {
 
 		onBoatMockLogicMessage := a.NewOnBoatMockLogicMessage(apiMsg, clientData)
 
-		GRPCChans.OnBoatChannel <- onBoatMockLogicMessage
+		select {
+		case GRPCChans.OnBoatChannel <- onBoatMockLogicMessage:
+		default:
+			Logger.Error().Msgf("could not place messaage on OnBoatChannel: %+v", onBoatMockLogicMessage)
+		}
 
 	case a.APIMessageTypeOffBoat:
 		Logger.Info().Msgf("Processing %s message to MockLogic from ConnName: %s, ConnType: %s",
@@ -123,7 +135,11 @@ func ProcessMessageToMockLogic(mlMsg *MockLogicMessage) {
 
 		offBoatMockLogicMessage := a.NewOffBoatMockLogicMessage(apiMsg, clientData)
 
-		GRPCChans.OffBoatChannel <- offBoatMockLogicMessage
+		select {
+		case GRPCChans.OffBoatChannel <- offBoatMockLogicMessage:
+		default:
+			Logger.Error().Msgf("could not place messaage on OffBoatChannel: %+v", offBoatMockLogicMessage)
+		}
 
 	default:
 		Logger.Warn().Msgf("Received unknown message type, %s, from ConnName: %s, ConnType: %s",

--- a/websocketserver/websocketservermodule/websocketserver_adapterreadloop.go
+++ b/websocketserver/websocketservermodule/websocketserver_adapterreadloop.go
@@ -49,7 +49,11 @@ func AdapterReadLoop(a *Client) error {
 			safeClients.Range(func(key, clientVal interface{}) bool {
 				client := clientVal.(*Client)
 
-				client.Write <- adapterMsg
+				select {
+				case client.Write <- adapterMsg:
+				default:
+					Logger.Error().Msgf("could not place messaage on client.Write: %+v", adapterMsg)
+				}
 
 				return true
 			})
@@ -64,7 +68,11 @@ func AdapterReadLoop(a *Client) error {
 			}
 			client = clientVal.(*Client)
 
-			client.Write <- adapterMsg
+			select {
+			case client.Write <- adapterMsg:
+			default:
+				Logger.Error().Msgf("could not place messaage on client.Write: %+v", adapterMsg)
+			}
 		}
 	}
 }

--- a/websocketserver/websocketservermodule/websocketserver_clientreadloop.go
+++ b/websocketserver/websocketservermodule/websocketserver_clientreadloop.go
@@ -43,7 +43,11 @@ func ClientReadLoop(c *Client) error {
 
 		// Check if adapter channel is open
 		if AdapterConn.Write != nil && !adapterLost {
-			AdapterConn.Write <- adapterMsg
+			select {
+			case AdapterConn.Write <- adapterMsg:
+			default:
+				Logger.Error().Msgf("could not place messaage on AdapterConn.Write: %+v", adapterMsg)
+			}
 		} else {
 			// The adapter connection and the write channel were lost. Reply with a close control message
 			Logger.Error().Msgf("Adapter write channel was lost. Cannot process message from client: %s, Sending close message with code 1011",


### PR DESCRIPTION
## What I did:

- Added `select` statements with default cases when placing messages on channels


## Why I did it:

The channels are buffered and should not fill up, but in the event they do reach their capacity and cannot accept another message, the `select` statement with a default option will prevent the application from locking up.


## How to test:

- Checkout this branch
- `cd riden`
- Run `make test`
- Ensure all unit tests pass

Closes #5 

