### PR TITLE
Logger InitializeLogger() should not return a zerolog.Logger

### DIFF
--- a/adapter/adaptermodule/adaptermodule.go
+++ b/adapter/adaptermodule/adaptermodule.go
@@ -15,14 +15,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/gorilla/websocket"
 	"google.golang.org/grpc"
 )
 
 // Logger Handles all log writing for the Adapter
-var Logger zerolog.Logger
+var Logger logger.Logger
 
 var LogDirectory string
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -10,10 +10,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
+type Logger struct {
+	zerolog.Logger
+}
+
 const timeFormat string = "2006-01-02 15:04:05.000000"
 
-func InitializeLogger(logFile, levelStr string) (zerolog.Logger, error) {
-	var logger zerolog.Logger
+func InitializeLogger(logFile, levelStr string) (Logger, error) {
+	var logger Logger
 	// Open file
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -60,7 +64,9 @@ func InitializeLogger(logFile, levelStr string) (zerolog.Logger, error) {
 		return filepath.Base(file) + ":" + strconv.Itoa(line)
 	}
 
-	logger = zerolog.New(f).With().Timestamp().Caller().Logger()
+	logger = Logger{
+		zerolog.New(f).With().Timestamp().Caller().Logger(),
+	}
 
 	return logger, err
 }

--- a/mocklogic/mocklogicmodule/mocklogicmodule.go
+++ b/mocklogic/mocklogicmodule/mocklogicmodule.go
@@ -15,12 +15,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 )
 
 // Logger Handles all log writing for the MockLogic
-var Logger zerolog.Logger
+var Logger logger.Logger
 
 var LogDirectory string
 

--- a/websocketserver/websocketservermodule/websocketservermodule.go
+++ b/websocketserver/websocketservermodule/websocketservermodule.go
@@ -11,13 +11,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/gorilla/websocket"
 )
 
 // Logger Handles all log writing for the WebSocketServer
-var Logger zerolog.Logger
+var Logger logger.Logger
 
 var LogDirectory string
 


### PR DESCRIPTION
## What I did:

- Changed InitializeLogger() to return a logger.Logger struct rather than a zerolog.Logger


## Why I did it:

By changing the return to a logger.Logger struct, the zerolog library only needs imported in the logger poackage and in any test file in which the zerolog logging level constants are needed.


## How to test:

- Check out this branch
- `cd riden`
- Run `make test`
- Ensure all unit tests pass

Closes #6 
