### PR TITLE
Signal channels should be changed to struct{}

### DIFF
--- a/adapter/adaptermodule/adapter_wssserverwriteloop.go
+++ b/adapter/adaptermodule/adapter_wssserverwriteloop.go
@@ -25,9 +25,8 @@ func WSServerWriteLoop(wsServer *WebSocketServerConnnection) error {
 			wsServer.Conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(WriteControlDeadline))
 			wsServer.KeepAliveTimer = time.AfterFunc(time.Duration(59*time.Second),
 				InitializeWebSocketServerConn)
-		case closeSignal := <-wsServer.Close:
-			Logger.Info().Msgf("WebSocket server write loop has received a close signal, %d",
-				closeSignal)
+		case <-wsServer.Close:
+			Logger.Info().Msg("WebSocket server write loop has received a close signal")
 			// handle close
 			return err
 		case adapterMsg := <-wsServer.Write:

--- a/adapter/adaptermodule/adaptermodule.go
+++ b/adapter/adaptermodule/adaptermodule.go
@@ -34,7 +34,7 @@ const WSChannelBufferSize int = 1024
 
 type WebSocketServerConnnection struct {
 	Conn  *websocket.Conn
-	Close chan int
+	Close chan struct{}
 	Write chan wss.AdapterMessage
 	// RetryStatusCodes contains the list of status codes to retry,
 	// use "x" as a wildcard for a single digit (default: [500])
@@ -48,7 +48,7 @@ func (ws *WebSocketServerConnnection) RemoteConnString() string {
 
 // Initialize sets up a client's channels and handlers
 func (ws *WebSocketServerConnnection) Initialize() {
-	ws.Close = make(chan int)
+	ws.Close = make(chan struct{})
 	ws.Write = make(chan wss.AdapterMessage, WSChannelBufferSize)
 
 	ws.Conn.SetPongHandler(func(msg string) error {

--- a/mocklogic/mocklogicmodule/mocklogic_simulationframes.go
+++ b/mocklogic/mocklogicmodule/mocklogic_simulationframes.go
@@ -385,9 +385,8 @@ func AdvanceSimFrames() {
 			}
 			SimFrameRing = SimFrameRing.Next()
 
-		case stopSignal := <-StopSimFrames:
-			Logger.Info().Msgf("AdvanceSimFrames has received a stop signal, %d",
-				stopSignal)
+		case <-StopSimFrames:
+			Logger.Info().Msg("AdvanceSimFrames has received a stop signal")
 			// handle close
 			return
 		}

--- a/mocklogic/mocklogicmodule/mocklogicmodule.go
+++ b/mocklogic/mocklogicmodule/mocklogicmodule.go
@@ -25,7 +25,7 @@ var LogDirectory string
 
 // Simulation frame related
 var SimFrameRing *ring.Ring
-var StopSimFrames chan int
+var StopSimFrames chan struct{}
 var SimFrameBoatStatusChannel chan a.BoatStatusAPIMessage
 var SimDockAdjacencyList map[string]*list.List
 

--- a/websocketserver/websocketservermodule/websocketserver_adapterwriteloop.go
+++ b/websocketserver/websocketservermodule/websocketserver_adapterwriteloop.go
@@ -18,9 +18,9 @@ func AdapterWriteLoop(a *Client) error {
 
 	for {
 		select {
-		case closeSignal := <-a.Close:
-			Logger.Info().Msgf("Client write loop for adapter connected at %s has received a close signal, %d",
-				remoteAddr, closeSignal)
+		case <-a.Close:
+			Logger.Info().Msgf("Client write loop for adapter connected at %s has received a close signal",
+				remoteAddr)
 			// handle close
 			return err
 		case adapterMsg := <-a.Write:

--- a/websocketserver/websocketservermodule/websocketserver_clientwriteloop.go
+++ b/websocketserver/websocketservermodule/websocketserver_clientwriteloop.go
@@ -15,9 +15,9 @@ func ClientWriteLoop(c *Client) error {
 
 	for {
 		select {
-		case closeSignal := <-c.Close:
-			Logger.Info().Msgf("Client write loop for client connected at %s has received a close signal, %d",
-				c.RemoteConnString(), closeSignal)
+		case <-c.Close:
+			Logger.Info().Msgf("Client write loop for client connected at %s has received a close signal",
+				c.RemoteConnString())
 			// handle close
 			return err
 		case adapterMsg := <-c.Write:

--- a/websocketserver/websocketservermodule/websocketserver_test.go
+++ b/websocketserver/websocketservermodule/websocketserver_test.go
@@ -439,7 +439,7 @@ func TestSendingMessageFromClientToAdapter(t *testing.T) {
 	Logger.Info().Msgf("Test attempting to close remote connection: %s", ws.LocalAddr().String())
 	ws.WriteControl(websocket.CloseMessage, msg, time.Now().Add(WriteControlDeadline))
 
-	AdapterConn.Close <- 0
+	AdapterConn.Close <- struct{}{}
 
 	// Adapter sends a close message with 1000 status code
 	Logger.Info().Msgf("Test attempting to close remote connection: %s", aws.LocalAddr().String())
@@ -539,7 +539,7 @@ func TestSendingMessageFromAdapterToClient(t *testing.T) {
 		t.Fatal("Error deleting client from safeClients in test clean-up")
 	}
 	client := clientVal.(*Client)
-	client.Close <- 0
+	client.Close <- struct{}{}
 
 	// Clients send a close message with 1000 status code
 	msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")

--- a/websocketserver/websocketservermodule/websocketservermodule.go
+++ b/websocketserver/websocketservermodule/websocketservermodule.go
@@ -24,7 +24,7 @@ var LogDirectory string
 // operations should occur on the connection.
 type Client struct {
 	WSConn *websocket.Conn
-	Close  chan int
+	Close  chan struct{}
 	Write  chan wss.AdapterMessage
 }
 
@@ -34,7 +34,7 @@ func (c *Client) RemoteConnString() string {
 
 // Initialize sets up a client's channels and handlers
 func (c *Client) Initialize() {
-	c.Close = make(chan int)
+	c.Close = make(chan struct{})
 	c.Write = make(chan wss.AdapterMessage, ChannelBufferSize)
 }
 


### PR DESCRIPTION
## What I did:

- Changed signal channels to empty struct


## Why I did it:

Channels used only for signaling should be an empty struct since the empty struct is zero bytes


## How to test:

- Check out this branch
- `cd riden`
- Run `make test`
- Ensure all unit tests pass

Closes #7 