### PR TITLE
Reduce channel buffer sizes

### DIFF
--- a/adapter/adaptermodule/adapter_mocklogiccommunication.go
+++ b/adapter/adaptermodule/adapter_mocklogiccommunication.go
@@ -49,7 +49,7 @@ func (grpcc *GRPCChannels) CloseOffBoat() {
 	close(grpcc.OffBoatChannel)
 }
 
-var GRPCChannelBufferSize int = 1024
+const GRPCChannelBufferSize int = 32
 
 var GRPCChans GRPCChannels
 

--- a/adapter/adaptermodule/adaptermodule.go
+++ b/adapter/adaptermodule/adaptermodule.go
@@ -30,7 +30,7 @@ var WriteControlDeadline time.Duration = 5 * time.Second
 
 var WSServerURL string = "ws://" + wss.WSServerHost + ":" + wss.WSServerPort + wss.WSServerAdapterPath
 
-const WSChannelBufferSize int = 1024
+const WSChannelBufferSize int = 32
 
 type WebSocketServerConnnection struct {
 	Conn  *websocket.Conn

--- a/websocketserver/websocketservermodule/websocketservermodule.go
+++ b/websocketserver/websocketservermodule/websocketservermodule.go
@@ -46,7 +46,7 @@ func (c *Client) CleanUpAfterReadLoop() {
 	c.WSConn.Close()
 }
 
-const ChannelBufferSize int = 1024
+const ChannelBufferSize int = 32
 
 // WriteControlDeadline is a duration of time to be added to the time of the
 // control message write operation


### PR DESCRIPTION
## What I did:

- Reduced the size of all channel buffers


## Why I did it:

Since Go allocates memory for a full buffer for a buffered channel, memory can be saved by reducing the buffer sizes. The buffers sizes do not need to be large for this application.


## How to test:

- Check out this branch
- `cd riden`
- Run `make test`
- Ensure all unit tests pass

Closes #15
